### PR TITLE
Dose/LET edges bug in DLVH computation: check for full dose/LET coverage

### DIFF
--- a/examples/07b_test_statistics_dlvh.py
+++ b/examples/07b_test_statistics_dlvh.py
@@ -18,7 +18,7 @@ import pydlvh.analyzer as analyzer
 
 def create_synthetic_patient(n_voxels=4000,
                              mu_dose=30.0, sigma_dose=7.0,
-                             mu_let=30.0, sigma_let=10.0,
+                             mu_let=30.0, sigma_let=1.0,
                              volume_rng=(80.0, 120.0)):
     """
         Create synthetic dose, let and relative volumes distributions.
@@ -36,6 +36,7 @@ def create_synthetic_patient(n_voxels=4000,
     relative_volumes = relative_volumes / relative_volumes.sum()
 
     volume_cc = np.random.uniform(*volume_rng)
+    
     return DLVH(dose=dose, let=let, volume_cc=volume_cc, relative_volumes=relative_volumes)
 
 def main():
@@ -45,13 +46,13 @@ def main():
     mu_dose_control, sigma_dose_control = 60.0, 5.0
     dose_shapes = [(x, np.abs(y)) for x, y in zip(np.random.normal(loc=mu_dose_control, scale=3.0, size=10), np.random.normal(loc=sigma_dose_control, scale=1.0, size=100))]
     control_dlvhs = [create_synthetic_patient(mu_dose=mu, sigma_dose=sd) for (mu, sd) in dose_shapes] # Control group
-    mu_dose_ae, sigma_dose_ae = 50.0, 5.0
+    mu_dose_ae, sigma_dose_ae = 50.0, 5.0 
     dose_shapes = [(x, np.abs(y)) for x, y in zip(np.random.normal(loc=mu_dose_ae, scale=3.0, size=10), np.random.normal(loc=sigma_dose_ae, scale=1.0, size=100))]
     ae_dlvhs = [create_synthetic_patient(mu_dose=mu, sigma_dose=sd) for (mu, sd) in dose_shapes] # Adverse event (AE) group
 
     # 2) Median DLVHs
     # Set manual uniform dose+let binning for aggregation
-    dose_edges = np.arange(0., 71, 1)  # D in [0, 70] with step 1 Gy
+    dose_edges = np.arange(0., 96, 1)  # D in [0, 95] with step 1 Gy
     let_edges = np.arange(0., 51, 1)  # LET in [0, 50] with step 1 keV/um
     print("\nAggregating control DLVHs...")
     all_control_dlvhs, median_control_dlvh = analyzer.aggregate(dlvhs=control_dlvhs,
@@ -100,7 +101,7 @@ def main():
     ax[1].set_title("Median AE DLVH")
     plt.tight_layout()
     plt.show()
-    
+
     # 5) Compute AUC map between control and AE DLVHs    
     print("\nComputing ROC-AUC score...")
     auc_map = analyzer.get_auc_score(control_histograms=all_control_dlvhs,

--- a/pydlvh/analyzer.py
+++ b/pydlvh/analyzer.py
@@ -331,6 +331,7 @@ def get_all_cohort_histograms(
     """ Return an array containing all the DVH/LVH/DLVHs from cohort after standardizing binning. """
 
     dlvhs = normalize_to_list(dlvhs)
+
     quantity = quantity or "dlvh" # default quantity: dlvh
     if quantity not in ["dvh", "lvh", "dlvh"]:
         raise ValueError(f"Unrecognized {quantity}. Please select 'dvh', 'lvh', or 'dlvh'.")

--- a/pydlvh/core.py
+++ b/pydlvh/core.py
@@ -647,6 +647,8 @@ class DLVH:
         # dose edges
         if dose_edges is not None:
             d_edges = np.asarray(dose_edges, dtype=float)
+            if np.max(d_edges) < np.max(self.dose):
+                raise ValueError("Provided dose_edges do not cover the maximum dose value.")
         elif bin_width_dose is None:
             d_edges = _auto_bins(array=self.dose)
         else:
@@ -657,6 +659,8 @@ class DLVH:
         # let edges
         if let_edges is not None:
             l_edges = np.asarray(let_edges, dtype=float)
+            if np.max(l_edges) < np.max(self.let):
+                raise ValueError("Provided l_edges do not cover the maximum dose value.")
         elif bin_width_let is None:
             l_edges = _auto_bins(array=self.let)
         else:

--- a/pydlvh/core.py
+++ b/pydlvh/core.py
@@ -626,7 +626,7 @@ class DLVH:
         if dose_edges is not None:
             d_edges = np.asarray(dose_edges, dtype=float)
         elif bin_width_dose is None:
-            d_edges = _auto_bins(arr=self.dose)
+            d_edges = _auto_bins(array=self.dose)
         else:
             dmax = float(np.max(self.dose))
             nd = int(np.ceil(dmax / bin_width_dose))
@@ -636,21 +636,23 @@ class DLVH:
         if let_edges is not None:
             l_edges = np.asarray(let_edges, dtype=float)
         elif bin_width_let is None:
-            l_edges = _auto_bins(arr=self.let)
+            l_edges = _auto_bins(array=self.let)
         else:
             lmax = float(np.max(self.let))
             nl = int(np.ceil(lmax / bin_width_let))
             l_edges = np.linspace(0.0, nl * bin_width_let, nl + 1)
 
         weights = self.relw * self.volume_cc
+
         vols, d_edges, l_edges = np.histogram2d(self.dose, self.let,
                                                 bins=(d_edges, l_edges),
                                                 weights=weights)
 
         values = _suffix_cumsum2d(vols) if cumulative else vols.astype(float)
+
         if normalize:
             values = (values / self.volume_cc) * 100.0
-
+            
         return Histogram2D(values=values,
                            dose_edges=d_edges,
                            let_edges=l_edges,

--- a/pydlvh/utils.py
+++ b/pydlvh/utils.py
@@ -67,17 +67,10 @@ def _auto_bins(*, array: np.ndarray, max_bins: int = 200) -> np.ndarray:
     """
     Suggest optimal bin edges for a 1D histogram.
 
-    Parameters
-    ----------
-    arr : np.ndarray
-        Input array to compute bin edges for.
-    max_bins : int, default=200
-        Maximum number of bins.
-
     Returns
     -------
-    bins : np.ndarray
-        Bin edges for arr.
+    edges : np.ndarray
+        Bin edges covering the data range.
     """
     return _freedman_diaconis_bins(data=array, max_bins=max_bins)
 


### PR DESCRIPTION
Now, if a user selects dose/let_edges that do not cover the entire dose/let array values provided an error arises.